### PR TITLE
Don't call api forms endpoint if there's no form to be shown

### DIFF
--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -218,6 +218,10 @@ if(!class_exists('WP_ConvertKit')) {
 			$form_id = intval(($form < 0) ? self::_get_settings('default_form') : $form);
 			$form = false;
 
+			if ($form_id == 0) {
+				return "";
+			}
+
 			$forms_available = self::$api->get_resources('forms');
 			foreach($forms_available as $form_available) {
 				if($form_available['id'] == $form_id) {


### PR DESCRIPTION
The plugin was requesting the api `/forms` endpoint for every page regardless of whether it needed to display a form or not.